### PR TITLE
fix: replace regex HTML pre-scan with linear scanner

### DIFF
--- a/packages/text-vide/src/__tests__/index.test.ts
+++ b/packages/text-vide/src/__tests__/index.test.ts
@@ -321,6 +321,30 @@ describe('with html tags', () => {
     expect(textVide(text)).toBe(expected);
   });
 
+  it('preserves tag ranges after an unterminated HTML comment opener', () => {
+    const text = 'aa <!-- bb <div>cd</div>';
+    const expected = '<b>a</b>a <!-- bb <div><b>c</b>d</div>';
+    expect(textVide(text)).toBe(expected);
+  });
+
+  it('continues highlighting after an unterminated comment with multiple tags', () => {
+    const text = 'x <!-- unterminated <div>ab</div> yy <i>cd</i>';
+    const expected =
+      'x <!-- unterminated <div><b>a</b>b</div> <b>y</b>y <i><b>c</b>d</i>';
+    expect(textVide(text)).toBe(expected);
+  });
+
+  it('treats an unterminated comment opener like a regular tag opener', () => {
+    const text = 'a <!-- foo';
+    const expected = 'a <!-- <b>fo</b>o';
+    expect(textVide(text)).toBe(expected);
+  });
+
+  it('ignores empty angle brackets', () => {
+    const text = '<>';
+    expect(textVide(text)).toBe('<>');
+  });
+
   it('complex html tags', () => {
     const text = `<div class="bionic-reader-container">
             

--- a/packages/text-vide/src/useCheckIsHtmlTag.ts
+++ b/packages/text-vide/src/useCheckIsHtmlTag.ts
@@ -11,14 +11,15 @@ const getHtmlTagRangeList = (text: string): MatchRange[] => {
     }
 
     if (text.startsWith('<!--', openIndex)) {
-      const closeIndex = text.indexOf('-->', openIndex + 4);
-      if (closeIndex === -1) {
-        break;
+      const commentCloseIndex = text.indexOf('-->', openIndex + 4);
+      if (commentCloseIndex !== -1) {
+        htmlTagRangeList.push([openIndex, commentCloseIndex + 2]);
+        cursor = commentCloseIndex + 3;
+        continue;
       }
-
-      htmlTagRangeList.push([openIndex, closeIndex + 2]);
-      cursor = closeIndex + 3;
-      continue;
+      // Unterminated `<!--`: fall through and treat the `<` as a normal
+      // tag opener so subsequent tags are still recognized (matches the
+      // behavior of the previous `/<!--[^]*?-->|<[^>]+>/g` regex).
     }
 
     const closeIndex = text.indexOf('>', openIndex + 1);

--- a/packages/text-vide/src/useCheckIsHtmlTag.ts
+++ b/packages/text-vide/src/useCheckIsHtmlTag.ts
@@ -1,10 +1,43 @@
-import { extractMatchRangeList } from './utils';
+import { MatchRange } from './utils';
 
-const HTML_TAG_REGEX = /<!--[^]*?-->|<[^>]+>/g;
+const getHtmlTagRangeList = (text: string): MatchRange[] => {
+  const htmlTagRangeList: MatchRange[] = [];
+  let cursor = 0;
+
+  while (cursor < text.length) {
+    const openIndex = text.indexOf('<', cursor);
+    if (openIndex === -1) {
+      break;
+    }
+
+    if (text.startsWith('<!--', openIndex)) {
+      const closeIndex = text.indexOf('-->', openIndex + 4);
+      if (closeIndex === -1) {
+        break;
+      }
+
+      htmlTagRangeList.push([openIndex, closeIndex + 2]);
+      cursor = closeIndex + 3;
+      continue;
+    }
+
+    const closeIndex = text.indexOf('>', openIndex + 1);
+    if (closeIndex === -1) {
+      break;
+    }
+
+    if (closeIndex > openIndex + 1) {
+      htmlTagRangeList.push([openIndex, closeIndex]);
+    }
+
+    cursor = closeIndex + 1;
+  }
+
+  return htmlTagRangeList;
+};
 
 export const useCheckIsHtmlTag = (text: string) => {
-  const htmlTagMatchList = text.matchAll(HTML_TAG_REGEX);
-  const htmlTagRangeList = extractMatchRangeList(htmlTagMatchList);
+  const htmlTagRangeList = getHtmlTagRangeList(text);
   const reversedHtmlTagRangeList = htmlTagRangeList.reverse();
 
   return (match: RegExpMatchArray) => {

--- a/packages/text-vide/src/utils.ts
+++ b/packages/text-vide/src/utils.ts
@@ -1,6 +1,8 @@
+export type MatchRange = [number, number];
+
 export const extractMatchRangeList = (
   matchList: IterableIterator<RegExpMatchArray>,
-) =>
+): MatchRange[] =>
   Array.from(matchList).map(match => {
     const startIndex = match.index!;
     const [matchedWord] = match;


### PR DESCRIPTION
### Motivation
- A default-on HTML tag pre-scan used a backtracking regex that can degrade to quadratic CPU time on inputs with many `<` characters or unterminated `<!--` comments, creating a CPU DoS risk when `ignoreHtmlTag` is enabled by default.
- The change replaces the expensive regex-based materialization with a safer linear scanner so the event loop is not blocked on attacker-controlled text.

### Description
- Replace the `matchAll`/regex pre-scan in `useCheckIsHtmlTag` with a linear `getHtmlTagRangeList` scanner that uses `indexOf` to find `<`, `>`, and `-->` boundaries.
- The scanner recognizes `<!-- ... -->` comments and normal `<...>` tags.
- Preserve external behavior by returning the same tag-inclusion predicate from `useCheckIsHtmlTag` and by producing the same range-list shape for downstream checks. In particular, an unterminated `<!--` falls through to normal `<...>` scanning so subsequent tags are still recognized — matching the original `/<!--[^]*?-->|<[^>]+>/g` behavior.
- Export a `MatchRange` type alias from `utils` and annotate `extractMatchRangeList`'s return type so the declaration build resolves the symbol.

### Follow-up fixes (9a91465)
Addresses the two findings from the Codex review on b06a7ac:
- **P1 — `MatchRange` import**: `utils.ts` did not export the type, which caused `TS2305` during `vite-plugin-dts` declaration emit. Now exported as `export type MatchRange = [number, number]`, and `extractMatchRangeList`'s signature is annotated to match.
- **P2 — unterminated `<!--` regression**: the initial scanner `break`'d on a missing `-->`, dropping every later tag. The scanner now falls through to the normal `<...>` handler so the `<` is treated as a regular tag opener, restoring the previous regex behavior.

### Testing
- `pnpm --filter text-vide test` — **51 tests passed** (47 → 51).
- Coverage: 100.00% statements / 100.00% branches / 100.00% functions / 100.00% lines (codecov patch & project both pass).
- `pnpm --filter text-vide build` — declaration emit succeeds with no TS errors.
- Regression tests added:
  - tag ranges preserved after unterminated `<!--`
  - multiple tags after an unterminated `<!--`
  - lone `<!--` opener with no further tags
  - empty `<>` is ignored

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e6daf89608333894f05ff8cab3b21)